### PR TITLE
Adjusted tsconfig to target ES2017 instead of ES2020

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "declarationDir": "types",
     "module": "CommonJS",
     "outDir": "dist",
-    "target": "ES2020",
+    "target": "ES2017",
     "removeComments": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,


### PR DESCRIPTION
Adjusted the TypeScript compiler configuration to target ES2017 to remove newer ES features like *optional chaining* from the output.