### PR TITLE
bugfix

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,6 @@ import { i18n, TFunction } from "i18next";
 declare module "vue/types/vue" {
     interface Vue {
         $t: TFunction;
-        $i18next: i18n;
 
         __bundles?: Array<[string, string]>;  // the bundles loaded by the component
         __key?: (key: string) => string; // local to each component with an <i18n> block
@@ -24,6 +23,8 @@ interface VueI18NextOptions {
 export default function install(Vue: typeof _Vue, { i18next }: VueI18NextOptions): void {
     Vue.mixin({
         beforeCreate() {
+            this.__key = undefined; // required to enable proxied access to `__key` in the $t function
+
             if (!this.$options.__i18n) return;
 
             // each component gets its own 8-digit random namespace prefixed with its name if available

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dotbase/vue-i18next",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dotbase/vue-i18next",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^4.1.3"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dotbase/vue-i18next",
   "description": "i18next integration for Vue",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "dot.base <movebase@charite.de> (https://movebase.de)",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
---
🧯 Bugfix
---

For components with no local `<i18n>`-block but `$t` calls (e.g. referring to keys stored in a global namespace), the variable `__key` was not set, causing a warning during rendering ("Property or method "__key" is not defined on the instance but referenced during render"), because the `this` object during rendering is actually a `Proxy` which warns upon usage of unknown variables.

That is, even optional chaining would not help, because the mere access by `this.__key` induces the warning (don't know, how this behaves for actual optional chaining, but we use a downcompiled version of the code).

### 🚒 Technical Solution
- [ ] Added an initialisation of `__key` in `beforeCreate` hook
